### PR TITLE
Update to Core 24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: eclipse
-base: core22
+base: core24
 
 version: 2024-12
 summary: Extensible Tool Platform and Java IDE
@@ -13,9 +13,9 @@ description:
 grade: stable
 confinement: classic
 
-architectures:
-- build-on: amd64
-- build-on: arm64
+platforms:
+  amd64:
+  arm64:
 
 apps:
   eclipse:
@@ -42,9 +42,9 @@ parts:
     build-attributes:
       - no-patchelf
     stage-packages:
-      - libffi7
+      - libffi8
       - libfreetype6
-      - libpng16-16
+      - libpng16-16t64
       - libgdk-pixbuf2.0-0
       - libsecret-1-0
       - libasound2


### PR DESCRIPTION
as since https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ we are no longer limited by thirdparty scripts based on QEMU for publishing!